### PR TITLE
Improve block extraction by comment style

### DIFF
--- a/src/parser/extractor.rs
+++ b/src/parser/extractor.rs
@@ -7,22 +7,87 @@ pub struct Block {
     pub body: String,
 }
 
-pub fn extract_blocks(text: &str, _style: &Style) -> Vec<Block> {
-    let re = Regex::new(r"(?m)^:::RESOURCE-START[\s\S]*?^:::RESOURCE-END$").unwrap();
+pub fn extract_blocks(text: &str, style: &Style) -> Vec<Block> {
     let mut res = Vec::new();
-    for mat in re.find_iter(text) {
-        let before = &text[..mat.start()];
-        let start_line = bytecount::count(before.as_bytes(), b'\n') + 1;
-        let block_text = mat.as_str();
-        let body_start = block_text.find('\n').map(|i| i + 1).unwrap_or(0);
-        let body_end = block_text.rfind('\n').unwrap_or(block_text.len());
-        let body = &block_text[body_start..body_end];
-        let end_line = start_line + bytecount::count(block_text.as_bytes(), b'\n');
-        res.push(Block {
-            start_line,
-            end_line,
-            body: body.to_string(),
-        });
+
+    if style.line.is_none() && style.block_start.is_none() {
+        // plain blocks without any comment markers
+        let bare_re = Regex::new(r"(?m)^:::RESOURCE-START[\s\S]*?^:::RESOURCE-END$").unwrap();
+        for mat in bare_re.find_iter(text) {
+            let before = &text[..mat.start()];
+            let start_line = bytecount::count(before.as_bytes(), b'\n') + 1;
+            let block_text = mat.as_str();
+            let body_start = block_text.find('\n').map(|i| i + 1).unwrap_or(0);
+            let body_end = block_text.rfind('\n').unwrap_or(block_text.len());
+            let body = &block_text[body_start..body_end];
+            let end_line = start_line + bytecount::count(block_text.as_bytes(), b'\n');
+            res.push(Block {
+                start_line,
+                end_line,
+                body: body.to_string(),
+            });
+        }
     }
+
+    if let Some(prefix) = style.line {
+        let pattern = format!(
+            r"(?m)^{0}\s*:::RESOURCE-START[\s\S]*?^{0}\s*:::RESOURCE-END$",
+            regex::escape(prefix)
+        );
+        let re = Regex::new(&pattern).unwrap();
+        for mat in re.find_iter(text) {
+            let before = &text[..mat.start()];
+            let start_line = bytecount::count(before.as_bytes(), b'\n') + 1;
+            let block_text = mat.as_str();
+            let body_start = block_text.find('\n').map(|i| i + 1).unwrap_or(0);
+            let body_end = block_text.rfind('\n').unwrap_or(block_text.len());
+            let raw_body = &block_text[body_start..body_end];
+            let body: String = raw_body
+                .lines()
+                .map(|l| {
+                    let mut line = l;
+                    if line.starts_with(prefix) {
+                        line = &line[prefix.len()..];
+                        if line.starts_with(' ') {
+                            line = &line[1..];
+                        }
+                    }
+                    line
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            let end_line = start_line + bytecount::count(block_text.as_bytes(), b'\n');
+            res.push(Block {
+                start_line,
+                end_line,
+                body,
+            });
+        }
+    }
+
+    if let (Some(start), Some(end)) = (style.block_start, style.block_end) {
+        let comment_pat = format!("{}[\\s\\S]*?{}", regex::escape(start), regex::escape(end));
+        let comment_re = Regex::new(&comment_pat).unwrap();
+        let delim_re = Regex::new(r":::RESOURCE-START[\s\S]*?:::RESOURCE-END").unwrap();
+        for comment in comment_re.find_iter(text) {
+            let comment_inner = &text[comment.start() + start.len()..comment.end() - end.len()];
+            for mat in delim_re.find_iter(comment_inner) {
+                let abs_start = comment.start() + start.len() + mat.start();
+                let before = &text[..abs_start];
+                let start_line = bytecount::count(before.as_bytes(), b'\n') + 1;
+                let block_text = mat.as_str();
+                let body_start = block_text.find('\n').map(|i| i + 1).unwrap_or(0);
+                let body_end = block_text.rfind('\n').unwrap_or(block_text.len());
+                let body = &block_text[body_start..body_end];
+                let end_line = start_line + bytecount::count(block_text.as_bytes(), b'\n');
+                res.push(Block {
+                    start_line,
+                    end_line,
+                    body: body.to_string(),
+                });
+            }
+        }
+    }
+
     res
 }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -4,6 +4,8 @@ mod tests {
     use crate::parser::extractor::*;
     use crate::parser::toml::*;
     use crate::parser::model::*;
+    use crate::parse_file;
+    use std::io::Write;
 
     #[test]
     fn detect_py() {
@@ -26,5 +28,31 @@ test = ""
         let doc = parse(&blocks[0].body).unwrap();
         let res = Resource::from_toml(doc, std::path::Path::new("a.txt"), blocks[0].start_line, blocks[0].end_line);
         assert_eq!(res.name, "x");
+    }
+
+    #[test]
+    fn line_comment_file() {
+        let content = "// :::RESOURCE-START\n// \"名前\" = \"line\"\n// \"概要\" = \"g\"\n// \"タイプ\" = \"code\"\n// :::RESOURCE-END\n";
+        let dir = std::env::temp_dir();
+        let path = dir.join("sample.rs");
+        let mut file = std::fs::File::create(&path).unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        let res = parse_file(&path).unwrap();
+        std::fs::remove_file(&path).ok();
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0].name, "line");
+    }
+
+    #[test]
+    fn block_comment_file() {
+        let content = "/*\n:::RESOURCE-START\n\"名前\" = \"block\"\n\"概要\" = \"g\"\n\"タイプ\" = \"code\"\n:::RESOURCE-END\n*/";
+        let dir = std::env::temp_dir();
+        let path = dir.join("sample.c");
+        let mut file = std::fs::File::create(&path).unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        let res = parse_file(&path).unwrap();
+        std::fs::remove_file(&path).ok();
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0].name, "block");
     }
 }


### PR DESCRIPTION
## Summary
- support comment styles when extracting blocks
- add new unit tests for line and block comment files

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6841052bdcc08332bab08903c6997229