### PR TITLE
Add parse CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,7 @@ anyhow = "1"
 thiserror = "1"
 tracing = "0.1"
 bytecount = "0.6"
+
+[[bin]]
+name = "coc-resources"
+path = "src/main.rs"

--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ Run tests with:
 ```bash
 cargo test
 ```
+
+## Command line usage
+
+Build and run the CLI to parse a file:
+
+```bash
+cargo run -- parse example.rs
+```

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,28 @@
+use std::path::PathBuf;
+use clap::{Parser, Subcommand};
+use anyhow::Result;
+use coc_resources::parse_file;
+
+#[derive(Parser)]
+#[command(name = "coc-resources", version, about = "CLI for coc-resources", propagate_version = true)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Parse a file and output resources as JSON
+    Parse { file: PathBuf },
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Parse { file } => {
+            let resources = parse_file(&file)?;
+            println!("{}", serde_json::to_string_pretty(&resources)?);
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a clap-based command line tool
- expose the binary via Cargo `[bin]`
- document how to run the CLI

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684105391af083329dbfc1dfeaa90cf6