### PR TITLE
Add tag parsing to Resource model

### DIFF
--- a/src/parser/model.rs
+++ b/src/parser/model.rs
@@ -11,6 +11,7 @@ pub struct Resource {
     pub name: String,
     pub summary: String,
     pub r#type: ResType,
+    pub tags: Vec<Tag>,
 }
 
 impl Resource {
@@ -26,6 +27,24 @@ impl Resource {
             "test" => ResType::Test,
             _ => ResType::Other,
         };
+        let tags = doc
+            .get("タグ")
+            .and_then(|item| item.as_table())
+            .map(|tbl| {
+                tbl.iter()
+                    .map(|(k, v)| {
+                        let desc = v
+                            .as_str()
+                            .map(|s| s.to_string())
+                            .and_then(|s| if s.is_empty() { None } else { Some(s) });
+                        Tag {
+                            tag: k.to_string(),
+                            description: desc,
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
         Resource {
             path: path.to_path_buf(),
             line_start: start,
@@ -33,6 +52,7 @@ impl Resource {
             name,
             summary,
             r#type,
+            tags,
         }
     }
 }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -28,6 +28,9 @@ test = ""
         let doc = parse(&blocks[0].body).unwrap();
         let res = Resource::from_toml(doc, std::path::Path::new("a.txt"), blocks[0].start_line, blocks[0].end_line);
         assert_eq!(res.name, "x");
+        assert_eq!(res.tags.len(), 1);
+        assert_eq!(res.tags[0].tag, "test");
+        assert!(res.tags[0].description.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- support tags on `Resource`
- parse `[タグ]` table in `from_toml`
- check tag parsing in unit tests

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68410f5c20708332a8964c98dcd147ba