### PR TITLE
Handle CRLF line endings in parser

### DIFF
--- a/src/parser/extractor.rs
+++ b/src/parser/extractor.rs
@@ -8,6 +8,11 @@ pub struct Block {
 }
 
 pub fn extract_blocks(text: &str, style: &Style) -> Vec<Block> {
+    // Normalize line endings so that regex patterns relying on `\n` work
+    // correctly for files with Windows-style CRLF endings.
+    let normalized_text = text.replace("\r\n", "\n").replace('\r', "\n");
+    let text = normalized_text.as_str();
+
     let mut res = Vec::new();
 
     if style.line.is_none() && style.block_start.is_none() {

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -58,4 +58,30 @@ test = ""
         assert_eq!(res.len(), 1);
         assert_eq!(res[0].name, "block");
     }
+
+    #[test]
+    fn line_comment_file_crlf() {
+        let content = "// :::RESOURCE-START\r\n// \"名前\" = \"line\"\r\n// \"概要\" = \"g\"\r\n// \"タイプ\" = \"code\"\r\n// :::RESOURCE-END\r\n";
+        let dir = std::env::temp_dir();
+        let path = dir.join("sample_crlf.rs");
+        let mut file = std::fs::File::create(&path).unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        let res = parse_file(&path).unwrap();
+        std::fs::remove_file(&path).ok();
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0].name, "line");
+    }
+
+    #[test]
+    fn block_comment_file_crlf() {
+        let content = "/*\r\n:::RESOURCE-START\r\n\"名前\" = \"block\"\r\n\"概要\" = \"g\"\r\n\"タイプ\" = \"code\"\r\n:::RESOURCE-END\r\n*/";
+        let dir = std::env::temp_dir();
+        let path = dir.join("sample_crlf.c");
+        let mut file = std::fs::File::create(&path).unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        let res = parse_file(&path).unwrap();
+        std::fs::remove_file(&path).ok();
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0].name, "block");
+    }
 }


### PR DESCRIPTION
## Summary
- normalize CRLF in `extract_blocks`
- add tests covering CRLF formatted files

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684111d222f08332adcd6c46c3be734a